### PR TITLE
fix: remove patch from modbus workflow

### DIFF
--- a/.github/workflows/wf-device-modbus.yml
+++ b/.github/workflows/wf-device-modbus.yml
@@ -11,10 +11,10 @@ jobs:
         with:
           edgex-repo: "device-modbus-go"
           canonical-repo: "edgex-device-modbus-go"
-          patch-file: "0001-snapcraft-version-patch.diff"
           ssh-private-key: ${{ secrets.SSH_CANONICAL_EDGEX_DEVICE_MODBUS }}    
   build-snap:
     runs-on: ubuntu-latest
+    needs: sync-repo
     steps:
     - name: Checkout code
       uses: actions/checkout@v2


### PR DESCRIPTION
The version patch has now been applied to upstream so
we don't need it.

Also added a dependency in the build-snap step on successful
completion of the sync-repo step. Without that dependency,
the snap would still build even if the patch failed.

Signed-off-by: Siggi Skulason <siggi.skulason@canonical.com>