### PR TITLE
Add workflow for edge build of RFID LLRP device and app snaps

### DIFF
--- a/.github/workflows/wf-device-rfid-llrp.yml
+++ b/.github/workflows/wf-device-rfid-llrp.yml
@@ -1,0 +1,61 @@
+name: EdgeX-Device-RFID-LLRP
+on: push
+  schedule:
+  - cron:  "0 6 * * *"
+jobs:
+#  sync-repo:
+#    runs-on: ubuntu-latest
+#    steps:      
+# TODO: commented out as this is still in a holding repository
+#      - name: Build and version device-rfid-llrp
+#        uses: canonical/edgex-sync-and-create-launchpad-branch-action@v1.4.0
+#        with:
+#          edgex-repo: "device-rfid-llrp-go"
+#          canonical-repo: "edgex-device-rfid-llrp-go"
+#          ssh-private-key: ${{ secrets.SSH_CANONICAL_EDGEX_DEVICE_RFID_LLRP }}
+#      - name: MM Failure
+#        if: ${{ failure() }}
+#        run: |
+#          curl -i -X POST -H 'Content-Type: application/json' -d '{"username" : "github-builds", "text" : "<!channel> :warning: Syncing repo failed [${{github.event_name}}] ${{github.workflow}} [See logs](https://github.com/canonical/edgex-sync/actions/runs/${{github.run_id}}) "}' ${{secrets.MATTERMOST}}
+  build-snap:
+    runs-on: ubuntu-latest
+ #   needs: sync-repo
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        repository: canonical/edgex-device-rfid-llrp-go
+        ref: master
+    - name: Build the snap
+      uses: snapcore/action-build@v1
+    - name: Uploading snap artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: snap-files
+        path: "*.snap"   
+# TODO: Add testing using the LLRP simulator
+#    - name: Test the snap
+#      uses: canonical/edgex-test-device-snap-action@v1.4
+#      with:
+#        edgex_device_snap: "edgex-device-rfid-llrp"
+#        edgex_service_name: "device-rfid-llrp-go"
+#        edgex_device_name: "Camera001"
+    - name: MM Failure
+      if: ${{ failure() }}
+      run: |
+        curl -i -X POST -H 'Content-Type: application/json' -d '{"username" : "github-builds", "text" : "<!channel> :warning: Build failed [${{github.event_name}}] ${{github.workflow}} [See logs](https://github.com/canonical/edgex-sync/actions/runs/${{github.run_id}}) "}' ${{secrets.MATTERMOST}}
+  build-launchpad:
+    runs-on: ubuntu-latest
+    needs:  build-snap
+    steps:
+      - name: Kick off Launchpad build
+        uses: canonical/edgex-launchpad-build-action@v1.4
+        with:
+          edgex_snap: "edgex-device-rfid-llrp"
+          consumer_name: ${{ secrets.LP_CONSUMER_NAME }}
+          access_token: ${{ secrets.LP_ACCESS_TOKEN }}
+          access_secret: ${{ secrets.LP_ACCESS_SECRET }}
+      - name: MM Failure
+        if: ${{ failure() }}
+        run: |
+          curl -i -X POST -H 'Content-Type: application/json' -d '{"username" : "github-builds", "text" : "<!channel> :warning: Launchpad build failed [${{github.event_name}}] ${{github.workflow}} [See logs](https://github.com/canonical/edgex-sync/actions/runs/${{github.run_id}}) "}' ${{secrets.MATTERMOST}}

--- a/.github/workflows/wf-rfid-llrp-inventory.yml
+++ b/.github/workflows/wf-rfid-llrp-inventory.yml
@@ -1,0 +1,53 @@
+name: edgex-rfid-llrp-inventory
+on: push
+  schedule:
+  - cron:  "0 6 * * *"
+jobs:
+#  sync-repo:
+#    runs-on: ubuntu-latest
+#    steps:      
+# TODO: commented out as this is still in a holding repository
+#      - name: Build and version rfid-llrp-inventory-service
+#        uses: canonical/edgex-sync-and-create-launchpad-branch-action@v1.4.0
+#        with:
+#          edgex-repo: "rfid-llrp-inventory-service"
+#          canonical-repo: "edgex-rfid-llrp-inventory-service"
+#          ssh-private-key: ${{ secrets.SSH_CANONICAL_EDGEX_DEVICE_RFID_LLRP }}
+#      - name: MM Failure
+#        if: ${{ failure() }}
+#        run: |
+#          curl -i -X POST -H 'Content-Type: application/json' -d '{"username" : "github-builds", "text" : "<!channel> :warning: Syncing repo failed [${{github.event_name}}] ${{github.workflow}} [See logs](https://github.com/canonical/edgex-sync/actions/runs/${{github.run_id}}) "}' ${{secrets.MATTERMOST}}
+  build-snap:
+    runs-on: ubuntu-latest
+ #   needs: sync-repo
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        repository: canonical/edgex-rfid-llrp-inventory-service
+        ref: master
+    - name: Build the snap
+      uses: snapcore/action-build@v1
+    - name: Uploading snap artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: snap-files
+        path: "*.snap"   
+      if: ${{ failure() }}
+      run: |
+        curl -i -X POST -H 'Content-Type: application/json' -d '{"username" : "github-builds", "text" : "<!channel> :warning: Build failed [${{github.event_name}}] ${{github.workflow}} [See logs](https://github.com/canonical/edgex-sync/actions/runs/${{github.run_id}}) "}' ${{secrets.MATTERMOST}}
+  build-launchpad:
+    runs-on: ubuntu-latest
+    needs:  build-snap
+    steps:
+      - name: Kick off Launchpad build
+        uses: canonical/edgex-launchpad-build-action@v1.4
+        with:
+          edgex_snap: "edgex-rfid-llrp-inventory"
+          consumer_name: ${{ secrets.LP_CONSUMER_NAME }}
+          access_token: ${{ secrets.LP_ACCESS_TOKEN }}
+          access_secret: ${{ secrets.LP_ACCESS_SECRET }}
+      - name: MM Failure
+        if: ${{ failure() }}
+        run: |
+          curl -i -X POST -H 'Content-Type: application/json' -d '{"username" : "github-builds", "text" : "<!channel> :warning: Launchpad build failed [${{github.event_name}}] ${{github.workflow}} [See logs](https://github.com/canonical/edgex-sync/actions/runs/${{github.run_id}}) "}' ${{secrets.MATTERMOST}}


### PR DESCRIPTION
Add minimal workflow files for 
- wf-device-rfid-llrp 
- wf-rfid-llrp-inventory

These workflows do a daily build of the snaps and if they succeed, then kick off
a build on Launchpad, which will in turn publish a snap to latest/edge

As the snaps are still in edgexfoundry-holding, syncing the repositories is
disabled for now. As the upstream snaps don't have a version tag,
the snaps will also be version 0.0.0

When the upstream repositories get moved into the edgexfoundry organization then
these workflows will be updated to process the sync and versioning correctly.

- Signed-off-by: Siggi Skulason <siggi.skulason@canonical.com>