### PR TITLE
build: update edgex-launchpad-build-action

### DIFF
--- a/.github/workflows/wf-edgexfoundry.yml
+++ b/.github/workflows/wf-edgexfoundry.yml
@@ -43,8 +43,10 @@ jobs:
     needs: test-snap
     steps:
       - name: Kick off Launchpad build
-        uses: canonical/edgex-launchpad-build-action@v1.4
+        uses: canonical/edgex-launchpad-build-action@v1.7
         with:
+          build1: "amd64"
+          build2: "arm64"
           edgex_snap: "edgexfoundry"
           consumer_name: ${{ secrets.LP_CONSUMER_NAME }}
           access_token: ${{ secrets.LP_ACCESS_TOKEN }}


### PR DESCRIPTION
- Update the version of edgex-launchpad-build-action to v1.7, to enable focal builder

Signed-off-by: Siggi Skulason <siggi.skulason@canonical.com>