### PR TITLE
build: switch all workflows to v1.7 edgex-launchpad-build-action

### DIFF
--- a/.github/workflows/wf-device-camera.yml
+++ b/.github/workflows/wf-device-camera.yml
@@ -35,8 +35,10 @@ jobs:
     needs:  build-snap
     steps:
       - name: Kick off Launchpad build
-        uses: canonical/edgex-launchpad-build-action@v1.4
+        uses: canonical/edgex-launchpad-build-action@v1.7
         with:
+          build1: "amd64"
+          build2: "arm64"
           edgex_snap: "edgex-device-camera"
           consumer_name: ${{ secrets.LP_CONSUMER_NAME }}
           access_token: ${{ secrets.LP_ACCESS_TOKEN }}

--- a/.github/workflows/wf-device-modbus.yml
+++ b/.github/workflows/wf-device-modbus.yml
@@ -28,8 +28,10 @@ jobs:
     needs: build-snap
     steps:
       - name: Kick off Launchpad build
-        uses: canonical/edgex-launchpad-build-action@v1.4
+        uses: canonical/edgex-launchpad-build-action@v1.7
         with:
+          build1: "amd64"
+          build2: "arm64"
           edgex_snap: "edgex-device-modbus"
           consumer_name: ${{ secrets.LP_CONSUMER_NAME }}
           access_token: ${{ secrets.LP_ACCESS_TOKEN }}

--- a/.github/workflows/wf-device-mqtt.yml
+++ b/.github/workflows/wf-device-mqtt.yml
@@ -28,8 +28,10 @@ jobs:
     needs:  build-snap
     steps:
       - name: Kick off Launchpad build
-        uses: canonical/edgex-launchpad-build-action@v1.4
+        uses: canonical/edgex-launchpad-build-action@v1.7
         with:
+          build1: "amd64"
+          build2: "arm64"
           edgex_snap: "edgex-device-mqtt"
           consumer_name: ${{ secrets.LP_CONSUMER_NAME }}
           access_token: ${{ secrets.LP_ACCESS_TOKEN }}

--- a/.github/workflows/wf-device-rest.yml
+++ b/.github/workflows/wf-device-rest.yml
@@ -28,8 +28,10 @@ jobs:
     needs:  build-snap
     steps:
       - name: Kick off Launchpad build
-        uses: canonical/edgex-launchpad-build-action@v1.4
+        uses: canonical/edgex-launchpad-build-action@v1.7
         with:
+          build1: "amd64"
+          build2: "arm64"
           edgex_snap: "edgex-device-rest"
           consumer_name: ${{ secrets.LP_CONSUMER_NAME }}
           access_token: ${{ secrets.LP_ACCESS_TOKEN }}

--- a/.github/workflows/wf-device-rfid-llrp.yml
+++ b/.github/workflows/wf-device-rfid-llrp.yml
@@ -28,8 +28,10 @@ jobs:
     needs: build-snap
     steps:
       - name: Kick off Launchpad build
-        uses: canonical/edgex-launchpad-build-action@v1.4
+        uses: canonical/edgex-launchpad-build-action@v1.7
         with:
+          build1: "amd64"
+          build2: "arm64"
           edgex_snap: "edgex-device-rfid-llrp"
           consumer_name: ${{ secrets.LP_CONSUMER_NAME }}
           access_token: ${{ secrets.LP_ACCESS_TOKEN }}

--- a/.github/workflows/wf-device-snmp.yml
+++ b/.github/workflows/wf-device-snmp.yml
@@ -28,8 +28,10 @@ jobs:
     needs: build-snap
     steps:
       - name: Kick off Launchpad build
-        uses: canonical/edgex-launchpad-build-action@v1.4
+        uses: canonical/edgex-launchpad-build-action@v1.7
         with:
+          build1: "amd64"
+          build2: "arm64"
           edgex_snap: "edgex-device-snmp"
           consumer_name: ${{ secrets.LP_CONSUMER_NAME }}
           access_token: ${{ secrets.LP_ACCESS_TOKEN }}

--- a/.github/workflows/wf-edgex-app-service-configurable.yml
+++ b/.github/workflows/wf-edgex-app-service-configurable.yml
@@ -28,8 +28,10 @@ jobs:
     needs:  build-snap
     steps:
       - name: Kick off Launchpad build
-        uses: canonical/edgex-launchpad-build-action@v1.4
+        uses: canonical/edgex-launchpad-build-action@v1.7
         with:
+          build1: "amd64"
+          build2: "arm64"
           edgex_snap: "edgex-app-service-configurable"
           consumer_name: ${{ secrets.LP_CONSUMER_NAME }}
           access_token: ${{ secrets.LP_ACCESS_TOKEN }}

--- a/.github/workflows/wf-edgex-cli.yml
+++ b/.github/workflows/wf-edgex-cli.yml
@@ -28,8 +28,10 @@ jobs:
     needs:  build-snap
     steps:
       - name: Kick off Launchpad build
-        uses: canonical/edgex-launchpad-build-action@v1.4
+        uses: canonical/edgex-launchpad-build-action@v1.7
         with:
+          build1: "amd64"
+          build2: "arm64"
           edgex_snap: "edgex-cli"
           consumer_name: ${{ secrets.LP_CONSUMER_NAME }}
           access_token: ${{ secrets.LP_ACCESS_TOKEN }}

--- a/.github/workflows/wf-edgex-ui.yml
+++ b/.github/workflows/wf-edgex-ui.yml
@@ -28,8 +28,10 @@ jobs:
     needs:  build-snap
     steps:
       - name: Kick off Launchpad build
-        uses: canonical/edgex-launchpad-build-action@v1.4
+        uses: canonical/edgex-launchpad-build-action@v1.7
         with:
+          build1: "amd64"
+          build2: "arm64"
           edgex_snap: "edgex-ui"
           consumer_name: ${{ secrets.LP_CONSUMER_NAME }}
           access_token: ${{ secrets.LP_ACCESS_TOKEN }}


### PR DESCRIPTION
Switch all these nightly builds to use focal instead of bionic repositories when building on Launchpad.

A future PR will make this more dynamic.