### PR TITLE
Add keepalive workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,6 +1,7 @@
 name: Nightly
 
 on:
+  workflow_dispatch:
   schedule:
   - cron:  "0 6 * * *"
 
@@ -38,3 +39,15 @@ jobs:
           consumer_name: ${{ secrets.LP_CONSUMER_NAME }}
           access_token: ${{ secrets.LP_ACCESS_TOKEN }}
           access_secret: ${{ secrets.LP_ACCESS_SECRET }}
+          
+  keepalive:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Run keepalive workflow
+        uses: gautamkrishnar/keepalive-workflow@master
+        with:
+          commit_message: keepalive
+          committer_username: github-actions[bot]
+          committer_email: github-actions[bot]@users.noreply.github.com

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,15 +38,16 @@ jobs:
           consumer_name: ${{ secrets.LP_CONSUMER_NAME }}
           access_token: ${{ secrets.LP_ACCESS_TOKEN }}
           access_secret: ${{ secrets.LP_ACCESS_SECRET }}
-          
+
+  # To keep the workflow active,
+  # add a commit if the project hasn't been active for 59 days.
+  # See https://github.com/canonical/edgex-sync/issues/20
   keepalive:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Run keepalive workflow
-        uses: gautamkrishnar/keepalive-workflow@master
+      - uses: actions/checkout@v2
+      - uses: gautamkrishnar/keepalive-workflow@master
         with:
-          commit_message: keepalive
           committer_username: github-actions[bot]
           committer_email: github-actions[bot]@users.noreply.github.com
+          time_elapsed: 59

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,8 +2,8 @@ name: Nightly
 
 on:
   workflow_dispatch:
-  schedule:
-  - cron:  "0 6 * * *"
+#   schedule:
+#   - cron:  "0 6 * * *"
 
 jobs:
   request-build:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,9 +1,8 @@
 name: Nightly
 
 on:
-  workflow_dispatch:
-#   schedule:
-#   - cron:  "0 6 * * *"
+  schedule:
+  - cron:  "0 6 * * *"
 
 jobs:
   request-build:


### PR DESCRIPTION
The keepalive workflow action has been run in my repo's [action](https://github.com/MonicaisHer/edgex-sync/runs/6877112902?check_suite_focus=true#step:3:1).
(please note the rest failed build workflows in above action are due to the Monicaisher repo does not have credentials for the launchpad.)

Closes https://github.com/canonical/edgex-sync/issues/20