### PR TITLE
Add ekuiper nightly build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,6 +16,7 @@ jobs:
           - edgexfoundry
           - edgex-cli
           - edgex-ui
+          - edgex-ekuiper
           - edgex-app-service-configurable
           - edgex-app-rfid-llrp-inventory
           - edgex-device-gpio

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Canonical publishes the following [EdgeX](https://www.edgexfoundry.org/) Snaps t
 - [edgexfoundry](https://snapcraft.io/edgexfoundry)
 - [edgex-cli](https://snapcraft.io/edgex-cli)
 - [edgex-ui](https://snapcraft.io/edgex-ui)
+- [edgex-ekuiper](https://snapcraft.io/edgex-ekuiper)
 - [edgex-app-service-configurable](https://snapcraft.io/edgex-app-service-configurable)
 - [edgex-app-rfid-llrp-inventory](https://snapcraft.io/edgex-app-rfid-llrp-inventory)
 - [edgex-device-gpio](https://snapcraft.io/edgex-device-gpio)


### PR DESCRIPTION
Add eKuiper nightly workflow to trigger the build of [edgex-ekuiper](https://github.com/canonical/edgex-ekuiper-snap) on Launchpad: https://launchpad.net/~canonical-edgex/+snap/edgex-ekuiper