### PR TITLE
Remove EdgeX CLI

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,7 +14,6 @@ jobs:
       matrix:
         snap:
           - edgexfoundry
-          - edgex-cli
           - edgex-ui
           - edgex-ekuiper
           - edgex-app-service-configurable

--- a/README.md
+++ b/README.md
@@ -1,21 +1,6 @@
 # EdgeX Snaps Nightly Build
 
-Canonical publishes the following [EdgeX](https://www.edgexfoundry.org/) Snaps to the Snap Store:
-- [edgexfoundry](https://snapcraft.io/edgexfoundry)
-- [edgex-cli](https://snapcraft.io/edgex-cli)
-- [edgex-ui](https://snapcraft.io/edgex-ui)
-- [edgex-ekuiper](https://snapcraft.io/edgex-ekuiper)
-- [edgex-app-service-configurable](https://snapcraft.io/edgex-app-service-configurable)
-- [edgex-app-rfid-llrp-inventory](https://snapcraft.io/edgex-app-rfid-llrp-inventory)
-- [edgex-device-gpio](https://snapcraft.io/edgex-device-gpio)
-- [edgex-device-modbus](https://snapcraft.io/edgex-device-modbus)
-- [edgex-device-mqtt](https://snapcraft.io/edgex-device-mqtt)
-- [edgex-device-rest](https://snapcraft.io/edgex-device-rest)
-- [edgex-device-rfid-llrp](https://snapcraft.io/edgex-device-rfid-llrp)
-- [edgex-device-snmp](https://snapcraft.io/edgex-device-snmp)
-- [edgex-device-usb-camera](https://snapcraft.io/edgex-device-usb-camera)
-- [edgex-device-virtual](https://snapcraft.io/edgex-device-virtual)
-- [edgex-device-onvif-camera](https://snapcraft.io/edgex-device-onvif-camera)
+Canonical publishes the several EdgeX snaps to the Snap Store.
 
 The snaps are built nightly from the [upstream](https://www.github.com/edgexfoundry) repos and published to the store under `latest/edge` channel.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,20 @@
 # EdgeX Snaps Nightly Build
 
-Canonical publishes the several EdgeX snaps to the Snap Store.
+Canonical publishes the following [EdgeX](https://www.edgexfoundry.org/) Snaps to the Snap Store:
+- [edgexfoundry](https://snapcraft.io/edgexfoundry)
+- [edgex-ui](https://snapcraft.io/edgex-ui)
+- [edgex-ekuiper](https://snapcraft.io/edgex-ekuiper)
+- [edgex-app-service-configurable](https://snapcraft.io/edgex-app-service-configurable)
+- [edgex-app-rfid-llrp-inventory](https://snapcraft.io/edgex-app-rfid-llrp-inventory)
+- [edgex-device-gpio](https://snapcraft.io/edgex-device-gpio)
+- [edgex-device-modbus](https://snapcraft.io/edgex-device-modbus)
+- [edgex-device-mqtt](https://snapcraft.io/edgex-device-mqtt)
+- [edgex-device-rest](https://snapcraft.io/edgex-device-rest)
+- [edgex-device-rfid-llrp](https://snapcraft.io/edgex-device-rfid-llrp)
+- [edgex-device-snmp](https://snapcraft.io/edgex-device-snmp)
+- [edgex-device-usb-camera](https://snapcraft.io/edgex-device-usb-camera)
+- [edgex-device-virtual](https://snapcraft.io/edgex-device-virtual)
+- [edgex-device-onvif-camera](https://snapcraft.io/edgex-device-onvif-camera)
 
 The snaps are built nightly from the [upstream](https://www.github.com/edgexfoundry) repos and published to the store under `latest/edge` channel.
 


### PR DESCRIPTION
[EdgeX CLI](https://github.com/edgexfoundry/edgex-cli) has been deprecated and will not have a v3 release.